### PR TITLE
Handle bytes when listing fonts in VideoClip.py

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1202,7 +1202,7 @@ class TextClip(ImageClip):
         lines = result.splitlines()
 
         if arg == 'font':
-            return [l[8:] for l in lines if l.startswith("  Font:")]
+            return [l.decode('UTF-8')[8:] for l in lines if l.startswith(b"  Font:")]
         elif arg == 'color':
             return [l.split(" ")[1] for l in lines[2:]]
 


### PR DESCRIPTION
I got a `TypeError` when calling `TextClip.list('font')`:

```
  File "/Users/me/.virtualenvs/project/lib/python3.4/site-packages/moviepy/video/VideoClip.py", line 1177, in <listcomp>
    return [l.decode('UTF-8')[8:] for l in lines if l.startswith("  Font:")]
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```

So now I'm just passing `bytes` to the `startswith` function as it's operating on bytes. Then decoding to `UTF-8` before it's returned.

If I need to do anything else, let me know :) This was just a quickfix.
